### PR TITLE
Fix PageProps typing for blog page

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { blogPosts } from '@/data/blog-posts'
 import { notFound } from 'next/navigation'
+import type { PageProps } from 'next'
 
 export async function generateStaticParams() {
   return blogPosts.map((post) => ({
@@ -7,7 +8,7 @@ export async function generateStaticParams() {
   }))
 }
 
-export default function BlogPostPage({ params }: { params: { slug: string } }) {
+export default function BlogPostPage({ params }: PageProps<{ slug: string }>) {
   const post = blogPosts.find((p) => p.slug === params.slug)
   
   if (!post) {


### PR DESCRIPTION
## Summary
- fix the `BlogPostPage` parameter type to use Next.js `PageProps`

## Testing
- `npm run build` *(fails: Cannot apply unknown utility class `bg-white`)*

------
https://chatgpt.com/codex/tasks/task_e_6888e81174988329bda16e515bcae748