### PR TITLE
Update homepage hero and blog setup

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -46,13 +46,15 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
             marginBottom: '24px',
             fontSize: '16px'
           }}>
-            {new Date(post.date).toLocaleDateString('en-US', { 
-              year: 'numeric', 
-              month: 'long', 
-              day: 'numeric' 
+            {new Date(post.date).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric'
             })}
             <span style={{ margin: '0 16px', color: '#e1e8ed' }}>•</span>
             {Math.ceil(post.content.split(' ').length / 200)} min read
+            <span style={{ margin: '0 16px', color: '#e1e8ed' }}>•</span>
+            {post.category}
           </p>
           
           <div style={{

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -17,7 +17,7 @@ export default function BlogPage() {
           color: '#14171a',
           marginBottom: '16px'
         }}>
-          Thoughts & Stories
+          False Memoirs
         </h1>
         <p style={{
           fontSize: '20px',
@@ -25,7 +25,7 @@ export default function BlogPage() {
           maxWidth: '600px',
           margin: '0 auto'
         }}>
-          Musings from a faceless creator
+          Stories and systems from behind the curtain
         </p>
       </section>
       

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,9 +3,10 @@ import Link from 'next/link'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'Favored Sinner - Surreal visuals. Bold designs.',
-  description: 'No face, just craft. Creative services and surreal digital art.',
-  keywords: 'surreal art, digital art, web design, creative services',
+  title: 'Favored Sinner - Art like a dream, tech like a machine',
+  description:
+    'Favored Sinner blends surreal digital art with DevOps, web design, storytelling, and strategy. One creative mind, many bold services. Explore the strange, the smart, and the intentional.',
+  keywords: 'surreal art, digital art, web design, devops, strategy, creative services',
 }
 
 export default function RootLayout({
@@ -83,6 +84,9 @@ export default function RootLayout({
             <p style={{ marginBottom: '8px' }}>© 2025 Favored Sinner</p>
             <p style={{ fontSize: '14px' }}>
               Contact: <a href="mailto:info@favoredsinner.com" style={{ color: '#1DA1F2', textDecoration: 'none' }}>info@favoredsinner.com</a>
+            </p>
+            <p style={{ fontSize: '14px', marginTop: '16px', color: '#657786' }}>
+              Built and run by a designer who writes false memoirs and a DevOps lead who sleeps next to his SSH keys.
             </p>
           </div>
         </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,14 +53,24 @@ export default function Home() {
             marginBottom: '24px',
             lineHeight: '1.1'
           }}>
-            Surreal visuals. Bold designs.
+            Art like a dream. Tech like a machine.
           </h1>
           <p style={{
             fontSize: 'clamp(1.25rem, 3vw, 2rem)',
             color: '#657786',
+            marginBottom: '24px'
+          }}>
+            I design, I deploy, I disturb comfort zones — with visuals, strategy, and code that all hit different.
+          </p>
+          <p style={{
+            fontSize: 'clamp(1rem, 2.5vw, 1.5rem)',
+            color: '#1DA1F2',
+            fontWeight: '500',
             marginBottom: '48px'
           }}>
-            No face, just craft.
+            <Link href="/gallery" style={{ textDecoration: 'none', color: '#1DA1F2' }}>
+              Explore the work
+            </Link>
           </p>
           
           <div style={{

--- a/src/app/quote/page.tsx
+++ b/src/app/quote/page.tsx
@@ -5,10 +5,10 @@ export default function QuotePage() {
     <div className="min-h-screen">
       <section className="max-w-4xl mx-auto px-6 py-12">
         <h1 className="text-4xl md:text-5xl font-serif text-center mb-4">
-          Request a Quote
+          Quotes &amp; Inquiries
         </h1>
         <p className="text-xl text-center text-deep-grey mb-12">
-          Tell us about your project and we&apos;ll get back to you within 24 hours
+          Tell us about your project and we&apos;ll get back to you within 24 hours.
         </p>
         
         <QuoteForm />

--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -41,13 +41,15 @@ export default function BlogCard({ post }: BlogCardProps) {
         alignItems: 'center',
         gap: '16px'
       }}>
-        <span>{new Date(post.date).toLocaleDateString('en-US', { 
-          year: 'numeric', 
-          month: 'long', 
-          day: 'numeric' 
+        <span>{new Date(post.date).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric'
         })}</span>
         <span style={{ color: '#e1e8ed' }}>•</span>
         <span>{Math.ceil(post.content.split(' ').length / 200)} min read</span>
+        <span style={{ color: '#e1e8ed' }}>•</span>
+        <span>{post.category}</span>
       </p>
       
       <p style={{

--- a/src/components/PayPalButton.tsx
+++ b/src/components/PayPalButton.tsx
@@ -8,13 +8,13 @@ export default function PayPalButton({ amount, description }: PayPalButtonProps)
   const paypalUrl = `https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=info@favoredsinner.com&item_name=${encodeURIComponent(description)}&amount=${amount}&currency_code=USD`
   
   return (
-    <a 
-      href={paypalUrl} 
-      target="_blank" 
+    <a
+      href={paypalUrl}
+      target="_blank"
       rel="noopener noreferrer"
       className="btn-outline text-sm inline-block"
     >
-      Pay with PayPal
+      Buy Now
     </a>
   )
 }

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Link from 'next/link'
 import StarRating from './StarRating'
+import PayPalButton from './PayPalButton'
 import { Service } from '@/data/services'
 
 interface ServiceCardProps {
@@ -98,33 +99,7 @@ export default function ServiceCard({ service }: ServiceCardProps) {
         >
           Request Quote
         </Link>
-        <button 
-          style={{
-            flex: '1',
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            border: '2px solid #1DA1F2',
-            color: '#1DA1F2',
-            padding: '10px 18px',
-            borderRadius: '50px',
-            fontWeight: '500',
-            fontSize: '14px',
-            backgroundColor: 'transparent',
-            cursor: 'pointer',
-            transition: 'all 0.3s ease'
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = '#1DA1F2';
-            e.currentTarget.style.color = 'white';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = 'transparent';
-            e.currentTarget.style.color = '#1DA1F2';
-          }}
-        >
-          Pay with PayPal
-        </button>
+        <PayPalButton amount={service.price?.replace(/[^\d.]/g, '') || '0'} description={service.title} />
       </div>
     </div>
   )

--- a/src/data/blog-posts.ts
+++ b/src/data/blog-posts.ts
@@ -4,6 +4,7 @@ export interface BlogPost {
   date: string
   excerpt: string
   content: string
+  category: 'Thought Pieces' | 'Dev/Infra Notes' | 'Visual Drops' | 'Growth Logs'
   tags: string[]
   slug: string
 }
@@ -15,6 +16,7 @@ export const blogPosts: BlogPost[] = [
     date: '2024-01-15',
     excerpt: 'Why choosing to remain faceless in the digital age is a form of art itself. In a world obsessed with personal branding, anonymity becomes a radical act of creative freedom.',
     content: `In a world obsessed with personal branding and self-promotion, choosing anonymity is a radical act. It's not about hiding; it's about letting the work speak for itself. When we remove the creator from the creation, we allow the audience to form a pure connection with the art itself. No preconceptions, no biases—just raw, unfiltered experience.`,
+    category: 'Thought Pieces',
     tags: ['thoughts', 'philosophy', 'art'],
     slug: 'art-of-being-anonymous'
   },
@@ -24,6 +26,7 @@ export const blogPosts: BlogPost[] = [
     date: '2024-01-10',
     excerpt: 'How technology has transformed the way we create and perceive surreal art. Digital tools have opened new dimensions for artistic expression beyond traditional boundaries.',
     content: `Digital tools have opened new dimensions for surrealist expression. We're no longer bound by physical limitations. Pixels bend to our will, reality morphs at our command. The surreal has become more accessible, yet maintaining its essence—that jarring disconnect from reality—requires even more intention in our oversaturated digital landscape.`,
+    category: 'Visual Drops',
     tags: ['art', 'technology', 'surrealism'],
     slug: 'surrealism-digital-era'
   },
@@ -33,6 +36,7 @@ export const blogPosts: BlogPost[] = [
     date: '2024-01-05',
     excerpt: 'Every image tells a story, but not all stories need words. Exploring how visual narratives can convey emotions and ideas that transcend language.',
     content: `Words can lie, but visuals speak directly to the soul. In my work, I explore how a single image can contain multitudes—layers of meaning that reveal themselves differently to each viewer. This is the democracy of art: each person brings their own story to the viewing, creating a unique narrative collaboration between creator and audience.`,
+    category: 'Thought Pieces',
     tags: ['storytelling', 'design', 'creativity'],
     slug: 'power-visual-storytelling'
   },
@@ -42,6 +46,7 @@ export const blogPosts: BlogPost[] = [
     date: '2023-12-28',
     excerpt: 'The creative process when you choose to work without recognition. How anonymity can liberate artistic expression and foster genuine innovation.',
     content: `Working in the shadows liberates the creative process. Without the pressure of maintaining a public persona, we can experiment freely, fail spectacularly, and evolve organically. The work becomes the only measure of success, not likes, not followers, not recognition—just the pure satisfaction of creation.`,
+    category: 'Thought Pieces',
     tags: ['creativity', 'process', 'philosophy'],
     slug: 'creating-in-shadows'
   }


### PR DESCRIPTION
## Summary
- update hero copy and CTA on the home page
- integrate PayPal buy buttons on service cards
- add footer personal touch and better metadata
- rename quote page and enhance blog layout
- categorize blog posts and show category labels

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688924b1f7448329b983cd2b8be45dfd